### PR TITLE
Fix 'Containter' typo

### DIFF
--- a/example/tree-editor-example/src/browser/tree-editor-example-frontend-module.ts
+++ b/example/tree-editor-example/src/browser/tree-editor-example-frontend-module.ts
@@ -12,7 +12,7 @@ import '../../src/browser/style/editor.css';
 import '@eclipse-emfcloud/theia-tree-editor/style/forms.css';
 import '@eclipse-emfcloud/theia-tree-editor/style/index.css';
 
-import { createBasicTreeContainter, NavigatableTreeEditorOptions } from '@eclipse-emfcloud/theia-tree-editor';
+import { createBasicTreeContainer, NavigatableTreeEditorOptions } from '@eclipse-emfcloud/theia-tree-editor';
 import { CommandContribution, MenuContribution } from '@theia/core';
 import { LabelProviderContribution, NavigatableWidgetOptions, OpenHandler, WidgetFactory } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
@@ -42,7 +42,7 @@ export default new ContainerModule(bind => {
     bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({
         id: TreeEditorWidget.WIDGET_ID,
         createWidget: (options: NavigatableWidgetOptions) => {
-            const treeContainer = createBasicTreeContainter(
+            const treeContainer = createBasicTreeContainer(
                 context.container,
                 TreeEditorWidget,
                 TreeModelService,

--- a/theia-tree-editor/DOCUMENTATION.MD
+++ b/theia-tree-editor/DOCUMENTATION.MD
@@ -123,7 +123,7 @@ To use the editor, you need to bind it in your frontend module (which exports a 
 However, you should not bind your implementations directly to the interfaces provided
 by the json forms tree package because this creates conflicts when when using multiple tree editor implementations in the same Theia instance.
 
-Instead, we provided a utility method `createBasicTreeContainter` that creates a new child container of the current context
+Instead, we provided a utility method `createBasicTreeContainer` that creates a new child container of the current context
 and binds all needed services inside the container.
 Because the bindings are then encapsulated in the child container, other editors are not affected by them.
 If you have additional services or values you need to bind for the creation of your editor,
@@ -144,7 +144,7 @@ export default new ContainerModule(bind => {
   id: "my-theia-tree-editor",
   createWidget: (options: NavigatableWidgetOptions) => {
     // This creates a new inversify Container with all the basic services needed for a theia tree editor.
-    const treeContainer = createBasicTreeContainter(
+    const treeContainer = createBasicTreeContainer(
     context.container,
     MyEditorWidget,
     MyModelService,

--- a/theia-tree-editor/src/browser/util.ts
+++ b/theia-tree-editor/src/browser/util.ts
@@ -52,7 +52,7 @@ function createTreeWidget(
  * @param modelService The tree editor's model service
  * @param nodeFactory The tree editor's node factory
  */
-export function createBasicTreeContainter(
+export function createBasicTreeContainer(
     parent: interfaces.Container,
     treeEditorWidget: interfaces.Newable<BaseTreeEditorWidget>,
     modelService: interfaces.Newable<TreeEditor.ModelService>,


### PR DESCRIPTION
* Rename createBasicTreeContainter to createBasicTreeContainer
* Adapt documentation
* Adapt example

Fix #25