### PR TITLE
Let TreeEditor.ModelService implementation be asynchronous #21

### DIFF
--- a/theia-tree-editor/src/browser/detail-form-widget.tsx
+++ b/theia-tree-editor/src/browser/detail-form-widget.tsx
@@ -98,14 +98,17 @@ export class DetailFormWidget extends BaseWidget {
         return stylingReducer(vanillaStyles, registerStylesAction);
     }
 
-    setSelection(selectedNode: TreeEditor.Node): void {
+    async setSelection(selectedNode: TreeEditor.Node): Promise<void> {
         this.selectedNode = selectedNode;
 
+        const data = await this.modelService.getDataForNode(this.selectedNode);
+        const schema = await this.modelService.getSchemaForNode(this.selectedNode);
+        const uiSchema = await this.modelService.getUiSchemaForNode(this.selectedNode);
         this.store.dispatch(
             Actions.init(
-                this.modelService.getDataForNode(this.selectedNode),
-                this.modelService.getSchemaForNode(this.selectedNode),
-                this.modelService.getUiSchemaForNode(this.selectedNode),
+                data,
+                schema,
+                uiSchema,
                 {
                     refParserOptions: {
                         dereference: { circular: 'ignore' }

--- a/theia-tree-editor/src/browser/interfaces.ts
+++ b/theia-tree-editor/src/browser/interfaces.ts
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { JsonSchema, UISchemaElement } from '@jsonforms/core';
+import { MaybePromise } from '@theia/core';
 import {
     CompositeTreeNode,
     DecoratedTreeNode,
@@ -74,7 +75,7 @@ export namespace TreeEditor {
          * @param node The tree node
          * @returns The data associated with the node
          */
-        getDataForNode(node: Node): any;
+        getDataForNode(node: Node): MaybePromise<any>;
 
         /**
          * Returns the JsonSchema describing how the node's data should be rendered.
@@ -82,7 +83,7 @@ export namespace TreeEditor {
          * @param node The tree node
          * @returns the JsonSchema describing the node's data or undefined to generate a schema.
          */
-        getSchemaForNode(node: Node): JsonSchema | undefined;
+        getSchemaForNode(node: Node): MaybePromise<JsonSchema> | undefined;
 
         /**
          * Returns the ui schema describing how the node's data should be rendered.
@@ -91,7 +92,7 @@ export namespace TreeEditor {
          * @param node The tree node
          * @returns The ui schema for the node's data or undefined to generate a ui schema.
          */
-        getUiSchemaForNode(node: Node): UISchemaElement | undefined;
+        getUiSchemaForNode(node: Node): MaybePromise<UISchemaElement> | undefined;
 
         /**
          * This mapping describes which child nodes can be created for a given type.


### PR DESCRIPTION
getDataForNode, getSchemaForNode and getUiSchemaForNode
can now have asynchronous implementation.
getChildrenMapping and getNameForType
can not be made asynchronous because of the theia core interfaces.