### PR TITLE
Let TreeEditor.ModelService implementation be asynchronous #21

### DIFF
--- a/theia-tree-editor/src/browser/detail-form-widget.tsx
+++ b/theia-tree-editor/src/browser/detail-form-widget.tsx
@@ -98,14 +98,17 @@ export class DetailFormWidget extends BaseWidget {
         return stylingReducer(vanillaStyles, registerStylesAction);
     }
 
-    setSelection(selectedNode: TreeEditor.Node): void {
+    async setSelection(selectedNode: TreeEditor.Node): Promise<void> {
         this.selectedNode = selectedNode;
 
+        const data = await this.modelService.getDataForNode(this.selectedNode);
+        const schema = await this.modelService.getSchemaForNode(this.selectedNode);
+        const uiSchema = await this.modelService.getUiSchemaForNode(this.selectedNode);
         this.store.dispatch(
             Actions.init(
-                this.modelService.getDataForNode(this.selectedNode),
-                this.modelService.getSchemaForNode(this.selectedNode),
-                this.modelService.getUiSchemaForNode(this.selectedNode),
+                data,
+                schema,
+                uiSchema,
                 {
                     refParserOptions: {
                         dereference: { circular: 'ignore' }

--- a/theia-tree-editor/src/browser/interfaces.ts
+++ b/theia-tree-editor/src/browser/interfaces.ts
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { JsonSchema, UISchemaElement } from '@jsonforms/core';
+import { MaybePromise } from '@theia/core';
 import {
     CompositeTreeNode,
     DecoratedTreeNode,
@@ -74,7 +75,7 @@ export namespace TreeEditor {
          * @param node The tree node
          * @returns The data associated with the node
          */
-        getDataForNode(node: Node): any;
+        getDataForNode(node: Node): MaybePromise<any>;
 
         /**
          * Returns the JsonSchema describing how the node's data should be rendered.
@@ -82,7 +83,7 @@ export namespace TreeEditor {
          * @param node The tree node
          * @returns the JsonSchema describing the node's data or undefined to generate a schema.
          */
-        getSchemaForNode(node: Node): JsonSchema | undefined;
+        getSchemaForNode(node: Node): MaybePromise<JsonSchema> | undefined;
 
         /**
          * Returns the ui schema describing how the node's data should be rendered.
@@ -91,7 +92,7 @@ export namespace TreeEditor {
          * @param node The tree node
          * @returns The ui schema for the node's data or undefined to generate a ui schema.
          */
-        getUiSchemaForNode(node: Node): UISchemaElement | undefined;
+        getUiSchemaForNode(node: Node): MaybePromise<UISchemaElement> | undefined;
 
         /**
          * This mapping describes which child nodes can be created for a given type.

--- a/theia-tree-editor/src/browser/interfaces.ts
+++ b/theia-tree-editor/src/browser/interfaces.ts
@@ -120,7 +120,7 @@ export namespace TreeEditor {
          * @param treeData The tree's data
          * @returns The tree's shown root nodes (not to confuse with the invisible RootNode)
          */
-        mapDataToNodes(treeData: TreeData): Node[];
+        mapDataToNodes(treeData: TreeData): MaybePromise<Node[]>;
 
         /**
          * Creates the corresponding TreeNode for the given data.
@@ -136,7 +136,7 @@ export namespace TreeEditor {
             parent?: Node,
             property?: string,
             indexOrKey?: number | string
-        ): Node;
+        ): MaybePromise<Node>;
 
         /**
          * @param node The node to create a child for

--- a/theia-tree-editor/src/browser/master-tree-widget.tsx
+++ b/theia-tree-editor/src/browser/master-tree-widget.tsx
@@ -226,7 +226,7 @@ export class MasterTreeWidget extends TreeWidget {
     protected async refreshModelChildren(): Promise<void> {
         if (this.model.root && TreeEditor.RootNode.is(this.model.root)) {
             const newTree =
-                !this.data || this.data.error ? [] : this.nodeFactory.mapDataToNodes(this.data);
+                !this.data || this.data.error ? [] : await this.nodeFactory.mapDataToNodes(this.data);
             this.model.root.children = newTree;
             this.model.refresh();
         }
@@ -293,9 +293,9 @@ export class MasterTreeWidget extends TreeWidget {
     /**
      * Updates the data of the given node and recreates its whole subtree. Refreshes the tree.
      */
-    public updateDataForSubtree(node: TreeEditor.Node, data: any): void {
+    public async updateDataForSubtree(node: TreeEditor.Node, data: any): Promise<void> {
         Object.assign(node.jsonforms.data, data);
-        const newNode = this.nodeFactory.mapData(data);
+        const newNode = await this.nodeFactory.mapData(data);
         node.name = newNode.name;
         node.children = newNode.children;
         this.model.refresh();
@@ -308,13 +308,15 @@ export class MasterTreeWidget extends TreeWidget {
      * @param data The data array to generate the new tree nodes from
      * @param property The property of the parent data which will contain the new nodes.
      */
-    public addChildren(node: TreeEditor.Node, data: any[], property: string): void {
+    public async addChildren(node: TreeEditor.Node, data: any[], property: string): Promise<void> {
         const currentValue = node.jsonforms.data[property];
         let index = 0;
         if (Array.isArray(currentValue)) {
             index = currentValue.length;
         }
-        data.map((d, i) => this.nodeFactory.mapData(d, node, property, index + i));
+        for (const { d, i } of data.map((d, i) => ({ d, i }))) {
+            await this.nodeFactory.mapData(d, node, property, index + i);
+        }
         this.updateIndex(node, property);
         this.model.refresh();
     }

--- a/theia-tree-editor/src/browser/resource/resource-tree-editor-widget.ts
+++ b/theia-tree-editor/src/browser/resource/resource-tree-editor-widget.ts
@@ -100,7 +100,7 @@ export abstract class ResourceTreeEditorWidget extends NavigatableTreeEditorWidg
         this.treeWidget.setData(treeData);
     }
 
-    protected deleteNode(node: Readonly<TreeEditor.Node>): void {
+    protected async deleteNode(node: Readonly<TreeEditor.Node>): Promise<void> {
         if (node.parent && TreeEditor.Node.is(node.parent)) {
             const propertyData = node.parent.jsonforms.data[node.jsonforms.property];
             if (Array.isArray(propertyData)) {
@@ -114,12 +114,12 @@ export abstract class ResourceTreeEditorWidget extends NavigatableTreeEditorWidg
             }
 
             // Data was changed in place but need to trigger tree updates.
-            this.treeWidget.updateDataForSubtree(node.parent, node.parent.jsonforms.data);
+            await this.treeWidget.updateDataForSubtree(node.parent, node.parent.jsonforms.data);
             this.handleChanged();
         }
     }
 
-    protected addNode({ node, type, property }: AddCommandProperty): void {
+    protected async addNode({ node, type, property }: AddCommandProperty): Promise<void> {
         // Create an empty object that only contains its type identifier
         const newData: { [k: string]: any } = {};
         newData[this.getTypeProperty()] = type;
@@ -130,12 +130,12 @@ export abstract class ResourceTreeEditorWidget extends NavigatableTreeEditorWidg
             node.jsonforms.data[property] = [];
         }
         node.jsonforms.data[property].push(newData);
-        this.treeWidget.updateDataForSubtree(node, node.jsonforms.data);
+        await this.treeWidget.updateDataForSubtree(node, node.jsonforms.data);
         this.handleChanged();
     }
 
-    protected handleFormUpdate(data: any, node: TreeEditor.Node): void {
-        this.treeWidget.updateDataForSubtree(node, data);
+    protected async handleFormUpdate(data: any, node: TreeEditor.Node): Promise<void> {
+        await this.treeWidget.updateDataForSubtree(node, data);
         this.handleChanged();
     }
 

--- a/theia-tree-editor/src/browser/tree-editor-widget.tsx
+++ b/theia-tree-editor/src/browser/tree-editor-widget.tsx
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { Title } from '@phosphor/widgets';
+import { MaybePromise } from '@theia/core';
 import { BaseWidget, Message, Saveable, SplitPanel, Widget } from '@theia/core/lib/browser';
 import { Emitter, Event, ILogger } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
@@ -120,7 +121,7 @@ export abstract class BaseTreeEditorWidget extends BaseWidget implements Saveabl
      *
      * @param node The tree node to delete
      */
-    protected abstract deleteNode(node: Readonly<TreeEditor.Node>): void;
+    protected abstract deleteNode(node: Readonly<TreeEditor.Node>): MaybePromise<void>;
 
     /**
      * Add a node to the tree.
@@ -132,7 +133,7 @@ export abstract class BaseTreeEditorWidget extends BaseWidget implements Saveabl
         node,
         type,
         property
-    }: AddCommandProperty): void;
+    }: AddCommandProperty): MaybePromise<void>;
 
     protected onAfterAttach(msg: Message): void {
         this.splitPanel.addWidget(this.treeWidget);
@@ -160,7 +161,7 @@ export abstract class BaseTreeEditorWidget extends BaseWidget implements Saveabl
     protected abstract handleFormUpdate(
         data: any,
         node: TreeEditor.Node
-    ): void;
+    ): MaybePromise<void>;
 
     public save(): void {
         // do nothing by default


### PR DESCRIPTION
getDataForNode, getSchemaForNode and getUiSchemaForNode
can now have asynchronous implementation.
getChildrenMapping and getNameForType
can not be made asynchronous because of the theia core interfaces.

Signed-off-by: vhemery <vincent.hemery@csgroup.eu>