### PR TITLE
Fix creation of add commands

### DIFF
--- a/theia-tree-editor/package.json
+++ b/theia-tree-editor/package.json
@@ -2,13 +2,17 @@
   "name": "@eclipse-emfcloud/theia-tree-editor",
   "version": "0.6.0",
   "license": "(EPL-2.0 OR MIT)",
-  "author": {
-    "name": "EclipseSource"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-emfcloud/theia-tree-editor.git"
   },
+  "contributors": [
+    {
+      "name": "Eclipse emf.cloud Project",
+      "email": "emfcloud-dev@eclipse.org",
+      "url": "https://projects.eclipse.org/projects/ecd.emfcloud"
+    }
+  ],
   "homepage": "https://www.eclipse.org/emfcloud/",
   "bugs": "https://github.com/eclipse-emfcloud/theia-tree-editor/issues",
   "main": "lib/browser/index.js",

--- a/theia-tree-editor/src/browser/interfaces.ts
+++ b/theia-tree-editor/src/browser/interfaces.ts
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { JsonSchema, UISchemaElement } from '@jsonforms/core';
-import { MaybePromise } from '@theia/core';
+import { Command, MaybePromise } from '@theia/core';
 import {
     CompositeTreeNode,
     DecoratedTreeNode,
@@ -143,6 +143,13 @@ export namespace TreeEditor {
          * @returns true if child nodes can be created
          */
         hasCreatableChildren(node: Node): boolean;
+    }
+
+    export interface AddCommandDescription {
+        parentType: string;
+        property: string;
+        type: string;
+        command: Command;
     }
 
     /**


### PR DESCRIPTION
When creating the add commands for the tree editor, the parent type should be taken into account, besides the type of the created node and the container feature. This ensures the uniqueness of command IDs and shows the command in the tree only when both the parent and the feature match.

Previously, commands were created only based on the type of the new node and the containing feature. When the same type of node can be added for two (or more) different parents under differently named container features, one command was created for each feature type, but they shared a command ID, which can lead to problems. Moreover, because the type of the new node is identical for the two commands, both of them were showing for the parent nodes that accepted children of the added type, although  the features the commands are contributing to are different and might not exist in the parent.

To test the broken behavior, change the children mapping in the example app (`example/tree-editor-example/src/browser/tree/tree-model.ts`) to the map below. When clicking on the add button in the tree, notice how two add commands for `Node` are present, although the Tree should only have one (for the `nodes` feature). The same broken state can be observed for the Node elements.
```
[
        [
            Type.Tree,
            [
                {
                    property: 'nodes',
                    children: [Type.Node]
                }
            ]
        ],
        [
            Type.Node,
            [
                {
                    property: 'children',
                    children: components
                }
            ]
        ]
    ]
```
![image](https://user-images.githubusercontent.com/6464495/136174119-981e5991-dcc4-42f9-b19d-dbd362fdb52b.png)
